### PR TITLE
Fix: Show subtitles

### DIFF
--- a/api/routes/main/watch_routes.py
+++ b/api/routes/main/watch_routes.py
@@ -101,6 +101,9 @@ async def watch(eps_title):
 
         # Subtitles
         subtitle_tracks = raw.get("tracks", [])
+        print(f"[Watch] Subtitle tracks received: {len(subtitle_tracks)} tracks")
+        if subtitle_tracks:
+            print(f"[Watch] First track sample: {subtitle_tracks[0] if subtitle_tracks else 'none'}")
 
         # Intro/outro markers
         intro = raw.get("intro")

--- a/api/scrapers/hianime/video_utils.py
+++ b/api/scrapers/hianime/video_utils.py
@@ -182,17 +182,29 @@ def proxy_video_sources(data: Dict[str, Any]) -> Dict[str, Any]:
 
     # Proxy tracks
     if "tracks" in data and isinstance(data["tracks"], list):
-        for track in data["tracks"]:
+        print(f"[Proxy] Processing {len(data['tracks'])} subtitle tracks")
+        for idx, track in enumerate(data["tracks"]):
             if not isinstance(track, dict):
                 continue
+
+            original_file = track.get("file")
+            original_url = track.get("url")
+
             for k in ("file", "url"):
                 if track.get(k):
-                    track[k] = encode_proxy(track[k])
+                    proxied = encode_proxy(track[k])
+                    track[k] = proxied
+                    print(f"[Proxy] Track {idx} ({track.get('label', 'unknown')}): {k} proxied")
+
+            if not original_file and not original_url:
+                print(f"[Proxy] Warning: Track {idx} has no file or url: {track}")
 
         # Sort tracks: english first, thumbnails last
         try:
             data["tracks"].sort(key=sort_subtitle_priority)
-        except Exception:
+            print(f"[Proxy] Sorted {len(data['tracks'])} tracks by priority")
+        except Exception as e:
+            print(f"[Proxy] Error sorting tracks: {e}")
             pass
 
     return data

--- a/api/static/js/videojs-player.js
+++ b/api/static/js/videojs-player.js
@@ -161,9 +161,12 @@ class VideoJSPlayer {
       return []
     }
 
+    console.log('[Subtitles] Raw subtitle data:', JSON.stringify(subtitles, null, 2))
+
     const tracks = subtitles
       .map((subtitle, index) => {
-        if (!subtitle.file || subtitle.file === "null" || subtitle.file === "") {
+        const subFile = subtitle.file || subtitle.url
+        if (!subFile || subFile === "null" || subFile === "") {
           console.warn(`[Subtitles] Invalid subtitle file for track ${index}:`, subtitle)
           return null
         }
@@ -171,12 +174,12 @@ class VideoJSPlayer {
         const isEnglish = subtitle.label && subtitle.label.toLowerCase().includes("english")
         const shouldBeDefault = isEnglish && this.settings.subtitleLanguage === "English" && this.currentLanguage === "sub"
 
-        console.log(`[Subtitles] Track ${index}: ${subtitle.label}, file: ${subtitle.file}, default: ${shouldBeDefault}`)
+        console.log(`[Subtitles] Track ${index}: ${subtitle.label}, file: ${subFile}, default: ${shouldBeDefault}`)
 
         return {
           kind: "subtitles",
-          src: subtitle.file,
-          srclang: subtitle.lang || "en",
+          src: subFile,
+          srclang: subtitle.lang || subtitle.srclang || "en",
           label: subtitle.label || `Subtitle ${index + 1}`,
           default: shouldBeDefault,
           mode: shouldBeDefault ? "showing" : "disabled",

--- a/api/templates/components/video-player.html
+++ b/api/templates/components/video-player.html
@@ -20,11 +20,13 @@
 
             {% if subtitles %}
                 {% for sub in subtitles %}
+                    {% if sub.file or sub.url %}
                     <track kind="subtitles"
-                        src="{{ sub.file or sub.src }}"
-                        srclang="{{ sub.lang }}"
-                        label="{{ sub.label }}"
+                        src="{{ sub.file or sub.url }}"
+                        srclang="{{ sub.lang or 'en' }}"
+                        label="{{ sub.label or 'Subtitle' }}"
                         {% if sub.default %} default {% endif %}>
+                    {% endif %}
                 {% endfor %}
             {% endif %}
         </video-js>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subtitles now load from either a file path or a URL.
  * Improved defaults: language falls back to detected code or “en,” and labels default to “Subtitle.”
  * Player only renders subtitle tracks when a valid source is present.

* **Bug Fixes**
  * Prevents invalid/empty subtitle sources from causing playback issues.

* **Chores**
  * Added debug logging for subtitle retrieval and video track processing to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->